### PR TITLE
refs #4340 リクエストメソッドをAPIドキュメントに合わせて修正

### DIFF
--- a/lib/sub_user/apps.rb
+++ b/lib/sub_user/apps.rb
@@ -4,22 +4,22 @@ module SendGridWebApi::SubUserModules
     
     def list options = {}
       options.merge!({:task => "getavailable"}) unless options[:task]
-      query_api(APP_URL, options)
+      query_post_api(APP_URL, options)
     end
 
     def activate options = {}
       options.merge!({:task => "activate"}) unless options[:task]
-      query_api(APP_URL, options)
+      query_post_api(APP_URL, options)
     end
 
     def deactivate options = {}
       options.merge!({:task => "deactivate"}) unless options[:task]
-      query_api(APP_URL, options)
+      query_post_api(APP_URL, options)
     end
 
     def current_settings options = {}
       options.merge!({:task => "getsettings"}) unless options[:task]
-      query_api(APP_URL, options)
+      query_post_api(APP_URL, options)
     end
 
     def customize options = {}

--- a/lib/sub_user/auth.rb
+++ b/lib/sub_user/auth.rb
@@ -3,7 +3,7 @@ module SendGridWebApi::SubUserModules
     
     def login options = {}
       auth_url = "apiv2/customer.auth.json"
-      query_api(auth_url, options)
+      query_post_api(auth_url, options)
     end
         
   end

--- a/lib/sub_user/bounces.rb
+++ b/lib/sub_user/bounces.rb
@@ -4,12 +4,12 @@ module SendGridWebApi::SubUserModules
     
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
-      query_api(BOUNCE_URL, options)
+      query_post_api(BOUNCE_URL, options)
     end
   
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(BOUNCE_URL, options)    
+      query_post_api(BOUNCE_URL, options)
     end
   end
 end

--- a/lib/sub_user/event_notification.rb
+++ b/lib/sub_user/event_notification.rb
@@ -1,20 +1,20 @@
 module SendGridWebApi::SubUserModules
   class EventNotification < SendGridWebApi::SubUser
     EVENT_URL = "apiv2/customer.eventposturl.json"
-    
+
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
-      query_api(EVENT_URL, options)
+      query_post_api(EVENT_URL, options)
     end
 
     def set options = {}
       options.merge!({:task => "set"}) unless options[:task]
-      query_api(EVENT_URL, options)
+      query_post_api(EVENT_URL, options)
     end
 
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(EVENT_URL, options)
+      query_post_api(EVENT_URL, options)
     end
-  end  
+  end
 end

--- a/lib/sub_user/invalid_emails.rb
+++ b/lib/sub_user/invalid_emails.rb
@@ -4,12 +4,12 @@ module SendGridWebApi::SubUserModules
     
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
-      query_api(INVALID_EMAILS_URL, options)
+      query_post_api(INVALID_EMAILS_URL, options)
     end
 
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(INVALID_EMAILS_URL, options)    
+      query_post_api(INVALID_EMAILS_URL, options)
     end
   end
 end

--- a/lib/sub_user/ip_management.rb
+++ b/lib/sub_user/ip_management.rb
@@ -3,20 +3,20 @@ module SendGridWebApi::SubUserModules
     def get options = {}
       options.merge!({:list => "all"}) unless options[:list]
       ip_management_get_url = "apiv2/customer.ip.json"
-      query_api(ip_management_get_url, options)
+      query_post_api(ip_management_get_url, options)
     end
 
     def usage_ip options = {}
       options.merge!({:task => "list"}) unless options[:task]
       ip_management_get_url = "apiv2/customer.sendip.json"
-      query_api(ip_management_get_url, options)
+      query_post_api(ip_management_get_url, options)
     end
 
     def assign_ip options = {}
       options.merge!({:task => "append"}) unless options[:task]
       options.merge!({:set  => "specify"}) unless options[:set]
       ip_management_get_url = "apiv2/customer.sendip.json"
-      query_api(ip_management_get_url, options)
+      query_post_api(ip_management_get_url, options)
     end
 
   end

--- a/lib/sub_user/limits.rb
+++ b/lib/sub_user/limits.rb
@@ -4,32 +4,32 @@ module SendGridWebApi::SubUserModules
     
     def get options = {}
       options.merge!({:task => "retrieve"}) unless options[:task]
-      query_api(LIMIT_URL, options)
+      query_post_api(LIMIT_URL, options)
     end
 
     def delete options = {}
       options.merge!({:task => "none"}) unless options[:task]
-      query_api(LIMIT_URL, options)    
+      query_post_api(LIMIT_URL, options)
     end
 
     def reset options = {}
       options.merge!({:task => "recurring"}) unless options[:task]
-      query_api(LIMIT_URL, options)    
+      query_post_api(LIMIT_URL, options)
     end
 
     def set_credits options = {}
       options.merge!({:task => "total"}) unless options[:task]
-      query_api(LIMIT_URL, options)    
+      query_post_api(LIMIT_URL, options)
     end
 
     def increment_credits options = {}
       options.merge!({:task => "increment"}) unless options[:task]
-      query_api(LIMIT_URL, options)    
+      query_post_api(LIMIT_URL, options)
     end
 
     def decrement_credits options = {}
       options.merge!({:task => "decrement"}) unless options[:task]
-      query_api(LIMIT_URL, options)    
+      query_post_api(LIMIT_URL, options)
     end
   end
 end

--- a/lib/sub_user/management.rb
+++ b/lib/sub_user/management.rb
@@ -3,55 +3,55 @@ module SendGridWebApi::SubUserModules
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
       management_get_url = "apiv2/customer.profile.json"
-      query_api(management_get_url, options)
+      query_post_api(management_get_url, options)
     end
   
     def add options = {}
       management_add_url = "apiv2/customer.add.json"
-      query_api(management_add_url, options)
+      query_post_api(management_add_url, options)
     end
 
     def enable options = {}
       management_enable_url = "apiv2/customer.enable.json"
-      query_api(management_enable_url, options)
+      query_post_api(management_enable_url, options)
     end
 
     def disable options = {}
       management_disable_url = "apiv2/customer.disable.json"
-      query_api(management_disable_url, options)
+      query_post_api(management_disable_url, options)
     end
 
     def website_enable options = {}
       management_website_enable_url = "apiv2/customer.website_enable.json"
-      query_api(management_website_enable_url, options)
+      query_post_api(management_website_enable_url, options)
     end
 
     def website_disable options = {}
       management_website_disable_url = "apiv2/customer.website_disable.json"
-      query_api(management_website_disable_url, options)
+      query_post_api(management_website_disable_url, options)
     end
   
     def update options = {}
       options.merge!(:task => "set") unless options[:task]
       management_update_url = "apiv2/customer.profile.json"
-      query_api(management_update_url, options)    
+      query_post_api(management_update_url, options)    
     end
 
     def update_password options = {}
       management_set_password_url = "apiv2/customer.password.json"
-      query_api(management_set_password_url, options)    
+      query_post_api(management_set_password_url, options)    
     end
 
     def update_username options = {}
       options.merge!({:task => "setUsername"}) unless options[:task]
       management_update_url = "apiv2/customer.profile.json"
-      query_api(management_update_url, options)    
+      query_post_api(management_update_url, options)    
     end
 
     def update_email options = {}
       options.merge!({:task => "setEmail"}) unless options[:task]
       management_update_url = "apiv2/customer.profile.json"
-      query_api(management_update_url, options)    
+      query_post_api(management_update_url, options)    
     end
   end
 end

--- a/lib/sub_user/monitor_records.rb
+++ b/lib/sub_user/monitor_records.rb
@@ -4,32 +4,32 @@ module SendGridWebApi::SubUserModules
     
     def get options = {}
       options.merge!({:task => "list"}) unless options[:task]
-      query_api(MONITOR_RECORD_URL, options)
+      query_post_api(MONITOR_RECORD_URL, options)
     end
     
     def create options = {}
       options.merge!({:task => "create"}) unless options[:task]
-      query_api(MONITOR_RECORD_URL, options)
+      query_post_api(MONITOR_RECORD_URL, options)
     end
 
     def edit options = {}
       options.merge!({:task => "edit"}) unless options[:task]
-      query_api(MONITOR_RECORD_URL, options)
+      query_post_api(MONITOR_RECORD_URL, options)
     end
 
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(MONITOR_RECORD_URL, options)
+      query_post_api(MONITOR_RECORD_URL, options)
     end
 
     def add_user options = {}
       options.merge!({:task => "append"}) unless options[:task]
-      query_api(MONITOR_RECORD_URL, options)
+      query_post_api(MONITOR_RECORD_URL, options)
     end
 
     def remove_user options = {}
       options.merge!({:task => "detach"}) unless options[:task]
-      query_api(MONITOR_RECORD_URL, options)
+      query_post_api(MONITOR_RECORD_URL, options)
     end
   end
 end

--- a/lib/sub_user/parse.rb
+++ b/lib/sub_user/parse.rb
@@ -4,17 +4,22 @@ module SendGridWebApi::SubUserModules
     
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
-      query_api(PARSE_URL, options)
+      query_post_api(PARSE_URL, options)
     end
 
     def set options = {}
       options.merge!({:task => "set"}) unless options[:task]
-      query_api(PARSE_URL, options)
+      query_post_api(PARSE_URL, options)
+    end
+
+    def update options = {}
+      options.merge!({:task => "update"}) unless options[:task]
+      query_post_api(PARSE_URL, options)
     end
 
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(PARSE_URL, options)
+      query_post_api(PARSE_URL, options)
     end
   end
 end

--- a/lib/sub_user/spam.rb
+++ b/lib/sub_user/spam.rb
@@ -1,15 +1,15 @@
 module SendGridWebApi::SubUserModules
   class Spam < SendGridWebApi::SubUser
     SPAM_URL = "api/user.spamreports.json"
-    
+
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
-      query_api(SPAM_URL, options)
+      query_post_api(SPAM_URL, options)
     end
 
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(SPAM_URL, options)    
+      query_post_api(SPAM_URL, options)
     end
   end
 end

--- a/lib/sub_user/stats.rb
+++ b/lib/sub_user/stats.rb
@@ -2,7 +2,7 @@ module SendGridWebApi::SubUserModules
   class Stats < SendGridWebApi::SubUser
     def get options = {}
       stats_get_url = "apiv2/customer.stats.json"
-      query_api(stats_get_url, options)
+      query_post_api(stats_get_url, options)
     end
-  end  
+  end
 end

--- a/lib/sub_user/unsubscribes.rb
+++ b/lib/sub_user/unsubscribes.rb
@@ -1,21 +1,20 @@
 module SendGridWebApi::SubUserModules
   class Unsubscribe < SendGridWebApi::SubUser
     UNSUBSCRIBE_URL = "api/user.unsubscribes.json"
-    
+
     def get options = {}
       options.merge!({:task => "get"}) unless options[:task]
-      query_api(UNSUBSCRIBE_URL, options)
+      query_post_api(UNSUBSCRIBE_URL, options)
     end
 
     def add options = {}
       options.merge!({:task => "add"}) unless options[:task]
-      query_api(UNSUBSCRIBE_URL, options)    
+      query_post_api(UNSUBSCRIBE_URL, options)
     end
 
-  
     def delete options = {}
       options.merge!({:task => "delete"}) unless options[:task]
-      query_api(UNSUBSCRIBE_URL, options)    
+      query_post_api(UNSUBSCRIBE_URL, options)
     end
   end
 end

--- a/lib/sub_user/white_label.rb
+++ b/lib/sub_user/white_label.rb
@@ -1,16 +1,15 @@
 module SendGridWebApi::SubUserModules
   class WhiteLabel < SendGridWebApi::SubUser
     WHITE_LABEL_URL = "apiv2/customer.whitelabel.json"
-    
+
     def get options = {}
       options.merge!({:task => "list"}) unless options[:task]
-      query_api(WHITE_LABEL_URL, options)
+      query_post_api(WHITE_LABEL_URL, options)
     end
 
     def add options = {}
       options.merge!({:task => "append"}) unless options[:task]
-      query_api(WHITE_LABEL_URL, options)
+      query_post_api(WHITE_LABEL_URL, options)
     end
-    
   end
 end

--- a/lib/web_api/blocks.rb
+++ b/lib/web_api/blocks.rb
@@ -7,7 +7,7 @@ module SendGridWebApi::Modules
 
     def delete options = {}
       block_delete_url = "blocks.delete.json"
-      query_api(block_delete_url, options)
+      query_post_api(block_delete_url, options)
     end
 
     def count options = {}

--- a/lib/web_api/bounces.rb
+++ b/lib/web_api/bounces.rb
@@ -7,7 +7,7 @@ module SendGridWebApi::Modules
 
     def delete options = {}
       bounce_delete_url = "bounces.delete.json"
-      query_api(bounce_delete_url, options)
+      query_post_api(bounce_delete_url, options)
     end
 
     def count options = {}

--- a/lib/web_api/invalid_emails.rb
+++ b/lib/web_api/invalid_emails.rb
@@ -7,7 +7,11 @@ module SendGridWebApi::Modules
 
     def delete options = {}
       invalid_email_delete_url = "invalidemails.delete.json"
-      query_api(invalid_email_delete_url, options)
-    end    
+      query_post_api(invalid_email_delete_url, options)
+    end
+
+    def count options = {}
+      invalid_emails_count_url = "invalidemails.count.json"
+      query_api(invalid_emails_count_url, options)
   end
 end

--- a/lib/web_api/parse.rb
+++ b/lib/web_api/parse.rb
@@ -7,12 +7,12 @@ module SendGridWebApi::Modules
 
     def set options = {}
       parse_email_set_url = "parse.set.json"
-      query_api(parse_email_set_url, options)
+      query_post_api(parse_email_set_url, options)
     end
 
     def delete options = {}
       parse_email_delete_url = "parse.delete.json"
-      query_api(parse_email_delete_url, options)
+      query_post_api(parse_email_delete_url, options)
     end
   end
 end

--- a/lib/web_api/profile.rb
+++ b/lib/web_api/profile.rb
@@ -7,23 +7,23 @@ module SendGridWebApi::Modules
 
     def set options = {}
       profile_set_url = "profile.set.json"
-      query_api(profile_set_url, options)
+      query_post_api(profile_set_url, options)
     end
 
     def set_password options = {}
       profile_set_password_url = "password.set.json"
-      query_api(profile_set_password_url, options)
+      query_post_api(profile_set_password_url, options)
     end
 
     def set_username options = {}
       profile_set_username_url = "profile.setUsername.json"
-      query_api(profile_set_username_url, options)
+      query_post_api(profile_set_username_url, options)
     end
 
     def set_email options = {}
       profile_set_email_url = "profile.setEmail.json"
-      query_api(profile_set_email_url, options)
+      query_post_api(profile_set_email_url, options)
     end
 
-  end  
+  end
 end

--- a/lib/web_api/spam.rb
+++ b/lib/web_api/spam.rb
@@ -7,7 +7,12 @@ module SendGridWebApi::Modules
 
     def delete options = {}
       spam_delete_url = "spamreports.delete.json"
-      query_api(spam_delete_url, options)
+      query_post_api(spam_delete_url, options)
+    end
+
+    def count options = {}
+      spams_count_url = "spamreports.count.json"
+      query_api(spams_count_url, options)
     end
   end
 end

--- a/lib/web_api/unsubscribes.rb
+++ b/lib/web_api/unsubscribes.rb
@@ -7,12 +7,12 @@ module SendGridWebApi::Modules
 
     def add options = {}
       unsubscribe_add_url = "unsubscribes.add.json"
-      query_api(unsubscribe_add_url, options)
+      query_post_api(unsubscribe_add_url, options)
     end
 
     def delete options = {}
       unsubscribe_delete_url = "unsubscribes.delete.json"
-      query_api(unsubscribe_delete_url, options)
+      query_post_api(unsubscribe_delete_url, options)
     end
   end
 end


### PR DESCRIPTION
[#4340 Fal'Cie】sendgrid_webapiのリクエストメソッドがAPIリファレンスと異なる](http://redmine.snva.jp/issues/4340)の対応です。確認をお願いします。
